### PR TITLE
Adding species profile info

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -3,7 +3,7 @@ import Dependencies._
 Global / onChangedBuildSource := ReloadOnSourceChanges
 Laika / sourceDirectories     := Seq(baseDirectory.value / "docs")
 
-ThisBuild / scalaVersion     := "3.5.0"
+ThisBuild / scalaVersion     := "3.5.1"
 ThisBuild / organization     := "org.fathomnet"
 ThisBuild / organizationName := "MBARI"
 ThisBuild / startYear        := Some(2021)

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,29 +2,29 @@ import sbt._
 
 object Dependencies {
 
-    private val circeVersion = "0.14.9"
+    private val circeVersion = "0.14.10"
     lazy val circeCore       = "io.circe" %% "circe-core"    % circeVersion
     lazy val circeGeneric    = "io.circe" %% "circe-generic" % circeVersion
     lazy val circeParser     = "io.circe" %% "circe-parser"  % circeVersion
 
     lazy val jansi = "org.fusesource.jansi" % "jansi" % "2.4.1"
 
-    lazy val logback  = "ch.qos.logback"               % "logback-classic" % "1.5.7"
+    lazy val logback  = "ch.qos.logback"               % "logback-classic" % "1.5.11"
     lazy val methanol = "com.github.mizosoft.methanol" % "methanol"        % "1.7.0"
-    lazy val munit    = "org.scalameta"               %% "munit"           % "1.0.1"
+    lazy val munit    = "org.scalameta"               %% "munit"           % "1.0.2"
     lazy val picocli  = "info.picocli"                 % "picocli"         % "4.7.6"
 
     lazy val slf4jJdk = "org.slf4j" % "slf4j-jdk-platform-logging" % "2.0.16"
 
-    private val tapirVersion  = "1.11.1"
+    private val tapirVersion  = "1.11.7"
     lazy val tapirStubServer  = "com.softwaremill.sttp.tapir"   %% "tapir-sttp-stub-server"  % tapirVersion
     lazy val tapirSwagger     = "com.softwaremill.sttp.tapir"   %% "tapir-swagger-ui-bundle" % tapirVersion
     lazy val tapirCirce       = "com.softwaremill.sttp.tapir"   %% "tapir-json-circe"        % tapirVersion
-    lazy val tapirCirceClient = "com.softwaremill.sttp.client3" %% "circe"                   % "3.9.8"
+    lazy val tapirCirceClient = "com.softwaremill.sttp.client3" %% "circe"                   % "3.10.1"
     lazy val tapirNetty       = "com.softwaremill.sttp.tapir"   %% "tapir-netty-server"      % tapirVersion
     lazy val tapirVertx       = "com.softwaremill.sttp.tapir"   %% "tapir-vertx-server"      % tapirVersion
 
     lazy val typesafeConfig = "com.typesafe" % "config" % "1.4.3"
-    lazy val zio            = "dev.zio"     %% "zio"    % "2.1.8"
+    lazy val zio            = "dev.zio"     %% "zio"    % "2.1.11"
     
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.10.1
+sbt.version=1.10.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,6 @@
-addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"        % "0.12.1")
+addSbtPlugin("ch.epfl.scala"     % "sbt-scalafix"        % "0.13.0")
 addSbtPlugin("com.codecommit"    % "sbt-github-packages" % "0.5.3")
-addSbtPlugin("com.github.sbt"    % "sbt-git"             % "2.0.1")
+addSbtPlugin("com.github.sbt"    % "sbt-git"             % "2.1.0")
 addSbtPlugin("com.github.sbt"    % "sbt-native-packager" % "1.10.4")
 addSbtPlugin("com.timushev.sbt"  % "sbt-updates"         % "0.6.4")
 addSbtPlugin("de.heikoseeberger" % "sbt-header"          % "5.10.0")

--- a/src/main/scala/org/fathomnet/worms/Data.scala
+++ b/src/main/scala/org/fathomnet/worms/Data.scala
@@ -69,3 +69,5 @@ final case class Data(rootNode: WormsNode, wormsConcepts: Seq[WormsConcept]):
             case (parent, Some(child)) =>
                 val newParent = parent.copy(children = Seq(child))
                 Some(newParent)
+
+

--- a/src/main/scala/org/fathomnet/worms/Data.scala
+++ b/src/main/scala/org/fathomnet/worms/Data.scala
@@ -7,6 +7,7 @@
 package org.fathomnet.worms
 
 import scala.collection.immutable.SortedMap
+import org.fathomnet.worms.io.WormsConcept
 
 /**
  * Wraps a Worms tree with untility methods for fast access.
@@ -17,7 +18,7 @@ import scala.collection.immutable.SortedMap
  *   Brian Schlining
  * @since 2022-03-17
  */
-final case class Data(rootNode: WormsNode):
+final case class Data(rootNode: WormsNode, wormsConcepts: Seq[WormsConcept]):
 
     /**
      * Map of [nodeName, Node] for both the name and alternate name of the node.

--- a/src/main/scala/org/fathomnet/worms/StateController.scala
+++ b/src/main/scala/org/fathomnet/worms/StateController.scala
@@ -9,6 +9,7 @@ package org.fathomnet.worms
 import org.fathomnet.worms.etc.jdk.Logging.given
 
 import scala.util.control.NonFatal
+import org.fathomnet.worms.State.data
 
 object StateController:
 
@@ -222,3 +223,16 @@ object StateController:
             //   .map(_.simple)
             //   .toList
         runSearch(search)
+
+    def details(name: String): Either[ErrorMsg, WormsDetails] =
+        for 
+            data         <- State.data
+                                .toRight(NotFound("The WoRMS dataset is missing; this may happen for a few seconds when the server starts. If this continues, please report it to the FathomNet team."))
+            names        <- synonyms(name)
+            acceptedName <- names.headOption.toRight(NotFound(s"Unable to find `$name`"))
+            wormsConcept <- data.wormsConcepts.find(_.names.exists(_.name == acceptedName)).toRight(NotFound(s"Unable to find `$name` accepted name of `$acceptedName`"))
+        yield
+
+            WormsDetails.from(acceptedName, wormsConcept)
+                .copy(alternateNames = names.tail)
+            

--- a/src/main/scala/org/fathomnet/worms/WormsDetails.scala
+++ b/src/main/scala/org/fathomnet/worms/WormsDetails.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) Monterey Bay Aquarium Research Institute 2022
+ *
+ * worms-server code is licensed under the MIT license.
+ */
+
+package org.fathomnet.worms
+
+import org.fathomnet.worms.io.WormsConcept
+
+case class WormsDetails(
+    name: String,
+    rank: String,
+    aphiaId: Long,
+    parentAphiaId: Option[Long] = None,
+    alternateNames: Seq[String] = Seq.empty,
+    isMarine: Option[Boolean] = None, 
+    isFreshwater: Option[Boolean] = None,
+    isTerrestrial: Option[Boolean] = None,
+    isExtinct: Option[Boolean] = None,
+    isBrackish: Option[Boolean] = None
+) {
+
+}
+
+object WormsDetails:
+    def from(acceptedName: String, wormsConcept: WormsConcept): WormsDetails = 
+        WormsDetails(
+            name = acceptedName,
+            rank = wormsConcept.rank,
+            aphiaId = wormsConcept.id,
+            parentAphiaId = wormsConcept.parentId,
+            alternateNames = wormsConcept.names.filterNot(_.isPrimary).map(_.name),
+            isMarine = wormsConcept.isMarine,
+            isFreshwater = wormsConcept.isFreshwater,
+            isTerrestrial = wormsConcept.isTerrestrial,
+            isExtinct = wormsConcept.isExtinct,
+            isBrackish = wormsConcept.isBrackish
+        )

--- a/src/main/scala/org/fathomnet/worms/api/DetailEndpoints.scala
+++ b/src/main/scala/org/fathomnet/worms/api/DetailEndpoints.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) Monterey Bay Aquarium Research Institute 2022
+ *
+ * worms-server code is licensed under the MIT license.
+ */
+
+package org.fathomnet.worms.api
+
+import scala.concurrent.ExecutionContext
+import org.fathomnet.worms.WormsDetails
+
+import sttp.tapir.generic.auto.*
+import sttp.tapir.json.circe.*
+import sttp.tapir.server.ServerEndpoint
+import sttp.tapir.{query, PublicEndpoint, *}
+import org.fathomnet.worms.etc.circe.CirceCodecs.given
+import scala.concurrent.Future
+import org.fathomnet.worms.StateController
+
+class DetailEndpoints(using ec: ExecutionContext) extends Endpoints {
+
+
+    private val tag = "Details"
+
+    val detailsEndpoint = 
+        baseEndpoint
+            .get
+            .in("details")
+            .in(path[String]("name"))
+            .out(jsonBody[WormsDetails])
+            .description("Returns details about a worms taxa.")
+            .tag(tag)
+
+    val detailsServerEndpoint: ServerEndpoint[Any, Future] =
+        detailsEndpoint.serverLogic((name: String) => Future(StateController.details(name)))
+
+
+    override def all: List[ServerEndpoint[Any, Future]] = List(detailsServerEndpoint)
+  
+}

--- a/src/main/scala/org/fathomnet/worms/api/SwaggerEndpoints.scala
+++ b/src/main/scala/org/fathomnet/worms/api/SwaggerEndpoints.scala
@@ -12,12 +12,15 @@ import sttp.tapir.swagger.bundle.SwaggerInterpreter
 
 import scala.concurrent.Future
 
-case class SwaggerEndpoints(nameEndpoints: NameEndpoints, taxaEndpoints: TaxaEndpoints):
+case class SwaggerEndpoints(nameEndpoints: NameEndpoints, 
+                            taxaEndpoints: TaxaEndpoints,
+                            detailEndpoints: DetailEndpoints):
 
     val all: List[ServerEndpoint[Any, Future]] =
         SwaggerInterpreter()
             .fromEndpoints[Future](
                 List(
+                    detailEndpoints.detailsEndpoint,
                     nameEndpoints.namesCountEndpoint,
                     nameEndpoints.namesEndpoint,
                     nameEndpoints.namesByAphiaId,

--- a/src/main/scala/org/fathomnet/worms/etc/circe/CirceCodecs.scala
+++ b/src/main/scala/org/fathomnet/worms/etc/circe/CirceCodecs.scala
@@ -13,6 +13,7 @@ import org.fathomnet.worms.{ErrorMsg, Names, Page, SimpleWormsNode, WormsNode}
 
 import java.net.{URI, URL}
 import scala.util.Try
+import org.fathomnet.worms.WormsDetails
 
 /**
  * JSON codecs for use with Circe. Usage:
@@ -40,6 +41,9 @@ object CirceCodecs:
     given urlEncoder: Encoder[URL] = Encoder
         .encodeString
         .contramap(_.toString)
+
+    given Decoder[WormsDetails] = deriveDecoder
+    given Encoder[WormsDetails] = deriveEncoder  
 
     given Decoder[WormsNode] = deriveDecoder
     given Encoder[WormsNode] = deriveEncoder

--- a/src/main/scala/org/fathomnet/worms/io/MutableWormsNode.scala
+++ b/src/main/scala/org/fathomnet/worms/io/MutableWormsNode.scala
@@ -71,7 +71,7 @@ object MutableWormsNodeBuilder:
         rows.filter(wc =>
             val lr = wc.rank.toLowerCase
             // (!lr.contains("species") && !lr.contains("variety")) || (!wc.isExtinct && wc.isMarine)
-            (!lr.contains("species") && !lr.contains("variety")) || (!wc.isExtinct)
+            (!lr.contains("species") && !lr.contains("variety")) || (!wc.isExtinct.getOrElse(false))
         )
 
     /**

--- a/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
+++ b/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
@@ -21,8 +21,11 @@ final case class WormsConcept(
     parentId: Option[Long],
     names: Seq[WormsConceptName],
     rank: String,
-    isMarine: Boolean = false,
-    isExtinct: Boolean = false
+    isMarine: Boolean = false, 
+    isFreshwater: Boolean = false,
+    isTerrestrial: Boolean = false,
+    isExtinct: Boolean = false,
+    isBrackish: Boolean = false
 )
 
 object WormsConcept:
@@ -49,7 +52,12 @@ object WormsConcept:
 
         for s <- speciesProfiles do
             val wc    = concepts(s.id)
-            val newWc = wc.copy(isMarine = s.isMarine, isExtinct = s.isExtinct)
+            val newWc = wc.copy(
+                isMarine = s.isMarine, 
+                isExtinct = s.isExtinct,
+                isBrackish = s.isBrackish,
+                isFreshwater = s.isFreshwater,
+                isTerrestrial = s.isTerrestrial)
             concepts(s.id) = newWc
 
         concepts

--- a/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
+++ b/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
@@ -21,11 +21,11 @@ final case class WormsConcept(
     parentId: Option[Long],
     names: Seq[WormsConceptName],
     rank: String,
-    isMarine: Boolean = false, 
-    isFreshwater: Boolean = false,
-    isTerrestrial: Boolean = false,
-    isExtinct: Boolean = false,
-    isBrackish: Boolean = false
+    isMarine: Option[Boolean] = None, 
+    isFreshwater: Option[Boolean] = None,
+    isTerrestrial: Option[Boolean] = None,
+    isExtinct: Option[Boolean] = None,
+    isBrackish: Option[Boolean] = None
 )
 
 object WormsConcept:

--- a/src/main/scala/org/fathomnet/worms/io/WormsLoader.scala
+++ b/src/main/scala/org/fathomnet/worms/io/WormsLoader.scala
@@ -30,7 +30,7 @@ object WormsLoader:
      * @param wormsDir
      *   The directory containing the Worms download
      */
-    def load(wormsDir: Path)(using ec: ExecutionContext): Option[WormsNode] =
+    def load(wormsDir: Path)(using ec: ExecutionContext): (Seq[WormsConcept], Option[WormsNode]) =
         val taxonPath          = wormsDir.resolve("taxon.txt")
         val vernacularNamePath = wormsDir.resolve("vernacularname.txt")
         val speciesProfilePath = wormsDir.resolve("speciesprofile.txt")
@@ -45,6 +45,6 @@ object WormsLoader:
             mutableRoot     <- ZIO.fromTry(Try(MutableWormsNodeBuilder.fathomNetTree(wormsConcepts)))
             root            <- ZIO.fromTry(Try(WormsNodeBuilder.from(mutableRoot)))
             _               <- ZIO.succeed(log.atInfo.log(s"Loaded WoRMS from $wormsDir"))
-        yield Some(root)
+        yield (wormsConcepts, Some(root))
 
-        ZioUtil.safeRun(app).getOrElse(None)
+        ZioUtil.safeRun(app).getOrElse((Seq.empty, None))

--- a/src/main/scala/org/fathomnet/worms/io/model.scala
+++ b/src/main/scala/org/fathomnet/worms/io/model.scala
@@ -61,14 +61,23 @@ object VernacularName:
 
     def read(file: String): List[VernacularName] = readFile(file, VernacularName.from)
 
-final case class SpeciesProfile(taxonID: String, isMarine: Boolean, isExtinct: Boolean):
+final case class SpeciesProfile(taxonID: String, 
+        isMarine: Boolean, 
+        isFreshwater: Boolean,
+        isTerrestrial: Boolean,
+        isExtinct: Boolean,
+        isBrackish: Boolean):
     val id = taxonIDToKey(taxonID)
 
 object SpeciesProfile:
+
+    private def toBool(value: String): Boolean =
+        value == "1"
+
     def from(row: String): Option[SpeciesProfile] =
         Try {
             val cols = row.split("\t")
-            SpeciesProfile(cols(0), cols(1) == "1", cols(4) == "1")
+            SpeciesProfile(cols(0), toBool(cols(1)), toBool(cols(2)), toBool(cols(3)), toBool(cols(4)), toBool(cols(5)))
         }.toOption
 
     def read(file: String): List[SpeciesProfile] = readFile(file, SpeciesProfile.from)

--- a/src/main/scala/org/fathomnet/worms/io/model.scala
+++ b/src/main/scala/org/fathomnet/worms/io/model.scala
@@ -62,17 +62,19 @@ object VernacularName:
     def read(file: String): List[VernacularName] = readFile(file, VernacularName.from)
 
 final case class SpeciesProfile(taxonID: String, 
-        isMarine: Boolean, 
-        isFreshwater: Boolean,
-        isTerrestrial: Boolean,
-        isExtinct: Boolean,
-        isBrackish: Boolean):
+        isMarine: Option[Boolean], 
+        isFreshwater: Option[Boolean],
+        isTerrestrial: Option[Boolean],
+        isExtinct: Option[Boolean],
+        isBrackish: Option[Boolean]):
     val id = taxonIDToKey(taxonID)
 
 object SpeciesProfile:
 
-    private def toBool(value: String): Boolean =
-        value == "1"
+    private def toBool(value: String): Option[Boolean] =
+        if value.isBlank then None
+        else Some(value == "1")
+
 
     def from(row: String): Option[SpeciesProfile] =
         Try {


### PR DESCRIPTION
The species profile data looks like:

```text
taxonID	isMarine	isFreshwater	isTerrestrial	isExtinct	isBrackish
urn:lsid:marinespecies.org:taxname:1	1	1	1		1
urn:lsid:marinespecies.org:taxname:2	1	1	1		1
urn:lsid:marinespecies.org:taxname:3	1	1	1		1
urn:lsid:marinespecies.org:taxname:4	1	1	1		1
urn:lsid:marinespecies.org:taxname:5	1	1	1		1
urn:lsid:marinespecies.org:taxname:6	1	1	1		1
urn:lsid:marinespecies.org:taxname:7	1	1	1		1
urn:lsid:marinespecies.org:taxname:8	1	1	1		1
urn:lsid:marinespecies.org:taxname:9	1				
urn:lsid:marinespecies.org:taxname:10	1	1	1		1
urn:lsid:marinespecies.org:taxname:11	1	1	1		1
urn:lsid:marinespecies.org:taxname:12	1				
urn:lsid:marinespecies.org:taxname:13	1				
urn:lsid:marinespecies.org:taxname:24	1				
urn:lsid:marinespecies.org:taxname:25	1	1	1		1
urn:lsid:marinespecies.org:taxname:26	1				
urn:lsid:marinespecies.org:taxname:51	1	1	1	0	1
urn:lsid:marinespecies.org:taxname:55	1				
urn:lsid:marinespecies.org:taxname:57	1				
urn:lsid:marinespecies.org:taxname:58	1				
urn:lsid:marinespecies.org:taxname:59	1	0	0	0	0
urn:lsid:marinespecies.org:taxname:63	1				
urn:lsid:marinespecies.org:taxname:64	1				
```

This pull request adds a single new endpoint: `/details`. Example: <https://fathomnet.org/worms/details/Annelida> would return the following:

```json
{
  "name": "Annelida",
  "rank": "Phylum",
  "aphiaId": 882,
  "parentAphiaId": 2,
  "alternateNames": [
    "Anneliden",
    "Borstenfüßer",
    "European sea mouse",
    "Gliederwürmer",
    "Ringelwürmer",
    "annelids",
    "gelede wormen",
    "ringmaskar",
    "ringwormen",
    "segmented worms",
    "Кільчасті черви",
    "環形動物門"
  ],
  "isMarine": true,
  "isFreshwater": true,
  "isTerrestrial": true,
  "isExtinct": false,
  "isBrackish": true
}
```

The goals of `details` are to provide @lauravchrobak with access to the `is*` flags. I did not return this info in the default taxa endpoints because:

1. It makes the JSON output much more verbose and the flags are of little general utility for most applications.
2. Adding the details give me a hook to add extended info in the future (like references, reference images, etc) without affecting the primary purpose of the worm-server (providing a fast naming-service for FathomNet)