### PR TITLE
#9 - make two passes through tree to rename correctly

### DIFF
--- a/src/main/scala/org/fathomnet/worms/AppConfig.scala
+++ b/src/main/scala/org/fathomnet/worms/AppConfig.scala
@@ -6,7 +6,7 @@
 
 package org.fathomnet.worms
 
-import com.typesafe.config.ConfigFactory
+import com.typesafe.config.{Config, ConfigFactory}
 
 import scala.util.Try
 
@@ -17,7 +17,7 @@ import scala.util.Try
  */
 object AppConfig:
 
-    val Config = ConfigFactory.load()
+    val Config: Config = ConfigFactory.load()
 
     val Name: String = "worms-server"
 

--- a/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
+++ b/src/main/scala/org/fathomnet/worms/io/WormsConcept.scala
@@ -71,7 +71,9 @@ object WormsConcept:
             )
             concepts(s.id) = newWc
 
-        makePrimaryNamesUnique(concepts.values)
+        concepts.values.toSeq
+
+//        makePrimaryNamesUnique(concepts.values)
 
     /**
      * WARNING: THIS IS A HACK
@@ -80,7 +82,7 @@ object WormsConcept:
      * the name is not unique.
      * @param wormsConcepts
      */
-    private def makePrimaryNamesUnique(nodes: Iterable[WormsConcept]): Seq[WormsConcept] =
+    def makePrimaryNamesUnique(nodes: Iterable[WormsConcept]): Seq[WormsConcept] =
         val map = mutable.Map[String, WormsConcept]()
 
         def addPossibleDuplicateName(node: WormsConcept): Unit =


### PR DESCRIPTION
In order to make a best attempt at converting all names in WoRMs to unique names we do the following:

- Load the WoRMS taxa
- Remove extinct species
- Build tree
- 1st pass - Remove the non-Animalia branches (we only care about animals for fathom net) 
- Flatten tree
- 2nd pass - Converting non-accepted names to unique names by appending a number when appropriate 
- Build tree